### PR TITLE
added logging for git context.  Added config files for running portag…

### DIFF
--- a/.custom-gatecheck.yml
+++ b/.custom-gatecheck.yml
@@ -1,0 +1,107 @@
+version: "1"
+
+metadata:
+    tags: []  # Additional metadata tags for the configuration
+
+# Grype scanner configuration (for container/dependency vulnerability scanning)
+grype:
+    # Maximum allowed vulnerabilities by severity level
+    severityLimit:
+        critical:
+            enabled: false  # Whether to enforce critical severity limits
+            limit: 0       # Maximum number of critical vulnerabilities allowed
+        high:
+            enabled: false
+            limit: 7
+        medium:
+            enabled: false
+            limit: 0
+        low:
+            enabled: false
+            limit: 0
+    
+    epssLimit:
+        enabled: false     # Whether to enforce EPSS (Exploit Prediction Scoring System) limits
+        score: 0          # Maximum allowed EPSS score
+    
+    kevLimitEnabled: false  # Whether to enforce Known Exploited Vulnerabilities (KEV) limits
+    
+    cveLimit:
+        enabled: false    # Whether to enforce specific CVE limits
+        cves: []         # List of specific CVEs to check against
+    
+    epssRiskAcceptance:
+        enabled: false    # Whether to accept risks based on EPSS scores
+        score: 0.001     # EPSS score threshold for risk acceptance
+    
+    cveRiskAcceptance:
+        enabled: false    # Whether to accept risks for specific CVEs
+        cves: []         # List of accepted CVEs
+
+# CycloneDX configuration (for Software Bill of Materials scanning)
+cyclonedx:
+    # Similar structure to grype configuration
+    # Controls vulnerability limits and risk acceptance for SBOM analysis
+    severityLimit:
+        critical:
+            enabled: false
+            limit: 0
+        high:
+            enabled: false
+            limit: 0
+        medium:
+            enabled: false
+            limit: 0
+        low:
+            enabled: false
+            limit: 0
+    epssLimit:
+        enabled: false
+        score: 0
+    kevLimitEnabled: false
+    cveLimit:
+        enabled: false
+        cves: []
+    epssRiskAcceptance:
+        enabled: false
+        score: 0
+    cveRiskAcceptance:
+        enabled: false
+        cves: []
+
+# Semgrep configuration (for static code analysis)
+semgrep:
+    # Maximum allowed findings by severity level
+    severityLimit:
+        error:
+            enabled: false
+            limit: 5      # Maximum number of error-level findings allowed
+        warning:
+            enabled: false
+            limit: 0
+        info:
+            enabled: false
+            limit: 0
+    
+    # Risk acceptance configuration based on impact levels
+    impactRiskAcceptance:
+        enabled: true     # Whether to use impact-based risk acceptance
+        high: false      # Whether to accept high-impact findings
+        medium: false    # Whether to accept medium-impact findings
+        low: true       # Whether to accept low-impact findings
+
+# Gitleaks configuration (for secrets scanning)
+gitleaks:
+    limitEnabled: false   # Whether to enforce limits on secrets findings
+
+# Code coverage requirements
+coverage:
+    lineThreshold: 0     # Minimum required line coverage percentage
+    functionThreshold: 0  # Minimum required function coverage percentage
+    branchThreshold: 0   # Minimum required branch coverage percentage
+
+# API configuration for submitting results
+api:
+    enabled: true                                        # Whether to submit results to API
+    endpoint: http://localhost:5168/Build/SubmitArtifacts # API endpoint for submitting results
+    skipVerify: true                                    # Whether to skip SSL verification

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ bin/
 dist/
 book/
 cover.cov
+artifacts/
+.env.local

--- a/.portage.yml
+++ b/.portage.yml
@@ -1,0 +1,50 @@
+# Base Configuration
+version: "1"
+imageTag: "ghcr.io/easy-up/gatecheck:latest"  # The full image tag for the target container image (e.g. my-org/my-app:latest)
+artifactDir: "artifacts"   # Directory for generated artifacts (e.g. ./artifacts) 
+gatecheckBundleFilename: "gatecheck-bundle.tar.gz"  # Filename for the gatecheck bundle (e.g. gatecheck-bundle.tar.gz)
+
+# Image Build Configuration
+imageBuild:
+  enabled: false           # Enable/Disable the image build pipeline (true/false)
+  buildDir: "."          # Build directory for image (e.g. ./cmd/portage)
+  dockerfile: "Dockerfile" # Dockerfile to use (e.g. ./cmd/portage/Dockerfile)
+  platform: ""           # Target platform (e.g. linux/amd64, linux/arm64)
+  target: ""            # Target stage for multi-stage builds (e.g. build, test, publish)
+  cacheTo: ""           # Cache export location (e.g. type=local,dest=path)
+  cacheFrom: ""         # Cache import location (e.g. type=local,src=path)  
+  squashLayers: false   # Whether to squash layers (true/false)
+  args: {}              # Build arguments (e.g. BUILD_ARGS=--build-arg=key=value)
+
+# Image Scan Configuration
+imageScan:
+  enabled: false           # Enable/Disable the image scan pipeline (true/false)
+  syftFilename: "syft-sbom-report.json" # Filename for the syft sbom report (e.g. syft-sbom-report.json)
+  grypeConfigFilename: "" # Filename for the grype config (e.g. grype-config.json)
+  grypeFilename: "grype-vulnerability-report-full.json" # Filename for the grype vulnerability report (e.g. grype-vulnerability-report-full.json)
+  clamavFilename: "clamav-virus-report.txt" # Filename for the clamav virus report (e.g. clamav-virus-report.txt)
+
+# Code Scan Configuration
+codeScan:
+  enabled: true           # Enable/Disable the code scan pipeline (true/false)
+  gitleaksFilename: "gitleaks-secrets-report.json"
+  gitleaksSrcDir: "."
+  semgrepFilename: "semgrep-sast-report.json" # Filename for the semgrep sast report (e.g. semgrep-sast-report.json)
+  semgrepRules: "p/default" # Semgrep rules to use (e.g. p/default)
+  semgrepExperimental: false # Whether to use experimental semgrep rules (true/false)
+  coverageFile: "" #"coverage/cobertura-coverage.xml"      # Externally generated code coverage file
+  semgrepSrcDir: "."    # Target directory for semgrep scan (e.g. ./cmd/portage)
+
+# Image Publish Configuration
+imagePublish:
+  enabled: false           # Enable/Disable the image publish pipeline (true/false)
+  bundleTag: "ghcr.io/easy-up/gatecheck:latest"         # Image tag for gatecheck bundle image blob (e.g. my-org/my-app:latest)
+
+# Deploy Configuration
+deploy:
+  enabled: true           # Enable/Disable the deploy pipeline (true/false).  When true, the .gatecheck.yml file is used, otherwise the default gatecheck config is used.
+  gatecheckConfigFilename: ".custom-gatecheck.yml"  # Filename for gatecheck config (e.g. gatecheck-config.json)
+  submit: false            # Whether to submit the artifacts to the configured API endpoint (true/false)
+  successWebhooks:
+    - url: "http://localhost:5168/Build/SubmitArtifacts"  # Using the same endpoint from .custom-gatecheck.yml for consistency
+      authorizationVar: "DEPLOY_WEBHOOK_AUTH_TOKEN"  # Environment variable containing the auth token

--- a/pkg/gatecheck/bundle.go
+++ b/pkg/gatecheck/bundle.go
@@ -67,6 +67,9 @@ func AppendToBundle(bundleRWS io.ReadWriteSeeker, src io.Reader, label string, t
 
 	// Validate the GitContext in the bundle
 	newContext, err := archive.GetContext()
+	if err != nil {
+		return err
+	}
 	if !compareContext(newContext, bundle.Manifest().Context) {
 		// The current context is different from the existing context. Clear all stale artifacts.
 		slog.Info("the git context hash changed, clearing stale bundle contents")

--- a/pkg/gatecheck/validate.go
+++ b/pkg/gatecheck/validate.go
@@ -5,12 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/easy-up/go-coverage"
 	"io"
 	"log/slog"
 	"slices"
 	"sort"
 	"strings"
+
+	"github.com/easy-up/go-coverage"
 
 	"github.com/gatecheckdev/gatecheck/pkg/archive"
 	"github.com/gatecheckdev/gatecheck/pkg/artifacts"
@@ -624,7 +625,7 @@ func validateGrypeReportWithFetch(r io.Reader, config *Config, options *fetchOpt
 
 	if err := LoadCatalogAndData(config, catalog, epssData, options); err != nil {
 		slog.Error("validate grype report: load epss data from file or api", "error", err)
-		return errors.New("Cannot run Grype validation: Cannot load external validation data. See log for details.")
+		return errors.New("cannot run Grype validation: cannot load external validation data - see log for details")
 	}
 
 	return validateGrypeFrom(r, config, catalog, epssData)
@@ -635,7 +636,7 @@ func validateGrypeFrom(r io.Reader, config *Config, catalog *kev.Catalog, epssDa
 	report := &artifacts.GrypeReportMin{}
 	if err := json.NewDecoder(r).Decode(report); err != nil {
 		slog.Error("decode grype report for validation", "error", err)
-		return errors.New("Cannot run Grype validation: Report decoding failed. See log for details.")
+		return errors.New("cannot run Grype validation: report decoding failed - see log for details")
 	}
 
 	return validateGrypeRules(config, report, catalog, epssData)
@@ -649,7 +650,7 @@ func validateCyclonedxReportWithFetch(r io.Reader, config *Config, options *fetc
 
 	if err := LoadCatalogAndData(config, catalog, epssData, options); err != nil {
 		slog.Error("validate cyclonedx report: load epss data from file or api", "error", err)
-		return errors.New("Cannot run Cyclonedx validation: Cannot load external validation data. See log for details.")
+		return errors.New("cannot run Cyclonedx validation: cannot load external validation data - see log for details")
 	}
 	return validateCyclonedxFrom(r, config, catalog, epssData)
 }
@@ -658,7 +659,7 @@ func validateCyclonedxFrom(r io.Reader, config *Config, catalog *kev.Catalog, ep
 	report := &artifacts.CyclonedxReportMin{}
 	if err := json.NewDecoder(r).Decode(report); err != nil {
 		slog.Error("decode cyclonedx report for validation", "error", err)
-		return errors.New("Cannot run Cyclonedx validation: Report decoding failed. See log for details.")
+		return errors.New("cannot run Cyclonedx validation: report decoding failed - see log for details")
 	}
 
 	return validateCyclonedxRules(config, report, catalog, epssData)
@@ -669,7 +670,7 @@ func validateSemgrepReport(r io.Reader, config *Config) error {
 	report := &artifacts.SemgrepReportMin{}
 	if err := json.NewDecoder(r).Decode(report); err != nil {
 		slog.Error("decode semgrep report for validation", "error", err)
-		return errors.New("Cannot run Semgrep report validation: Report decoding failed. See log for details.")
+		return errors.New("cannot run Semgrep report validation: report decoding failed - see log for details")
 	}
 
 	return validateSemgrepRules(config, report)
@@ -680,7 +681,7 @@ func validateGitleaksReport(r io.Reader, config *Config) error {
 	report := &artifacts.GitLeaksReportMin{}
 	if err := json.NewDecoder(r).Decode(report); err != nil {
 		slog.Error("decode gitleaks report for validation", "error", err)
-		return errors.New("Cannot run Semgrep report validation: Report decoding failed. See log for details.")
+		return errors.New("cannot run Semgrep report validation: report decoding failed - see log for details")
 	}
 	return validateGitleaksRules(config, report)
 }
@@ -736,7 +737,7 @@ func validateBundle(r io.Reader, config *Config, options *fetchOptions) error {
 	bundle := archive.NewBundle()
 	if err := archive.UntarGzipBundle(r, bundle); err != nil {
 		slog.Error("decode gatecheck bundle")
-		return errors.New("Cannot run Gatecheck Bundle validation: Bundle decoding failed. See log for details.")
+		return errors.New("cannot run Gatecheck Bundle validation: bundle decoding failed - see log for details")
 	}
 
 	catalog := kev.NewCatalog()
@@ -744,7 +745,7 @@ func validateBundle(r io.Reader, config *Config, options *fetchOptions) error {
 
 	if err := LoadCatalogAndData(config, catalog, epssData, options); err != nil {
 		slog.Error("validate cyclonedx report: load epss data from file or api", "error", err)
-		return errors.New("Cannot run Cyclonedx validation: Cannot load external validation data. See log for details.")
+		return errors.New("cannot run Cyclonedx validation: cannot load external validation data - see log for details")
 	}
 
 	var errs error
@@ -799,7 +800,7 @@ func validateGrypeRules(config *Config, report *artifacts.GrypeReportMin, catalo
 	})
 	// 1. Deny List - Fail Matching
 	if !ruleGrypeCVEDeny(config, report) {
-		return newValidationErr("Grype: CVE explicitly denied")
+		return newValidationErr("grype: CVE explicitly denied")
 	}
 
 	// Ignore any CVEs that don't meet the vulnerability threshold or the EPPS threshold
@@ -810,7 +811,7 @@ func validateGrypeRules(config *Config, report *artifacts.GrypeReportMin, catalo
 
 	// 3. KEV Catalog Limit - fail matching
 	if !ruleGrypeKEVLimit(config, report, catalog) {
-		return newValidationErr("Grype: CVE matched to KEV Catalog")
+		return newValidationErr("grype: CVE matched to KEV Catalog")
 	}
 
 	// 4. EPSS Allowance - remove from matches
@@ -818,12 +819,12 @@ func validateGrypeRules(config *Config, report *artifacts.GrypeReportMin, catalo
 
 	// 5. EPSS Limit - Fail Exceeding TODO: Implement
 	if !ruleGrypeEPSSLimit(config, report, data) {
-		return newValidationErr("Grype: EPSS Limit Exceeded")
+		return newValidationErr("grype: EPSS Limit Exceeded")
 	}
 
 	// 6. Severity Count Limit
 	if !ruleGrypeSeverityLimit(config, report) {
-		return newValidationErr("Grype: Severity Limit Exceeded")
+		return newValidationErr("grype: severity limit exceeded")
 	}
 
 	return nil
@@ -832,7 +833,7 @@ func validateGrypeRules(config *Config, report *artifacts.GrypeReportMin, catalo
 func validateCyclonedxRules(config *Config, report *artifacts.CyclonedxReportMin, catalog *kev.Catalog, data *epss.Data) error {
 	// 1. Deny List - Fail Matching
 	if !ruleCyclonedxCVEDeny(config, report) {
-		return newValidationErr("CycloneDx: CVE explicitly denied")
+		return newValidationErr("cycloneDx: CVE explicitly denied")
 	}
 
 	// 2. CVE Allowance - remove from matches
@@ -840,7 +841,7 @@ func validateCyclonedxRules(config *Config, report *artifacts.CyclonedxReportMin
 
 	// 3. KEV Catalog Limit - fail matching
 	if !ruleCyclonedxKEVLimit(config, report, catalog) {
-		return newValidationErr("CycloneDx: CVE Matched to KEV Catalog")
+		return newValidationErr("cycloneDx: CVE matched to KEV Catalog")
 	}
 
 	// 4. EPSS Allowance - remove from matches
@@ -848,12 +849,12 @@ func validateCyclonedxRules(config *Config, report *artifacts.CyclonedxReportMin
 
 	// 5. EPSS Limit - Fail Exceeding
 	if !ruleCyclonedxEPSSLimit(config, report, data) {
-		return newValidationErr("CycloneDx: EPSS Limit Exceeded")
+		return newValidationErr("cycloneDx: EPSS Limit Exceeded")
 	}
 
 	// 6. Severity Count Limit
 	if !ruleCyclonedxSeverityLimit(config, report) {
-		return newValidationErr("CycloneDx: Severity Limit Exceeded")
+		return newValidationErr("cycloneDx: severity limit exceeded")
 	}
 
 	return nil
@@ -869,7 +870,7 @@ func validateSemgrepRules(config *Config, report *artifacts.SemgrepReportMin) er
 
 	// 2. Severity Count Limit
 	if !ruleSemgrepSeverityLimit(config, report) {
-		return newValidationErr("Semgrep: Severity Limit Exceeded")
+		return newValidationErr("semgrep: severity limit exceeded")
 	}
 
 	return nil
@@ -878,7 +879,7 @@ func validateSemgrepRules(config *Config, report *artifacts.SemgrepReportMin) er
 func validateGitleaksRules(config *Config, report *artifacts.GitLeaksReportMin) error {
 	// 1. Limit Secrets - fail
 	if !ruleGitLeaksLimit(config, report) {
-		return newValidationErr("Gitleaks: Secrets Detected")
+		return newValidationErr("gitleaks: secrets detected")
 	}
 	return nil
 }

--- a/pkg/gatecheck/validate.go
+++ b/pkg/gatecheck/validate.go
@@ -19,7 +19,7 @@ import (
 	"github.com/gatecheckdev/gatecheck/pkg/kev"
 )
 
-var ErrValidationFailure = errors.New("Validation Failure")
+var ErrValidationFailure = errors.New("validation Failure")
 
 func newValidationErr(details string) error {
 	return fmt.Errorf("%w: %s", ErrValidationFailure, details)
@@ -63,7 +63,7 @@ func Validate(config *Config, reportSrc io.Reader, targetFilename string, option
 
 	default:
 		slog.Error("unsupported file type, cannot be determined from filename", "filename", targetFilename)
-		return errors.New("Failed to validate artifact. See log for details.")
+		return errors.New("failed to validate artifact. See log for details")
 	}
 }
 


### PR DESCRIPTION
Added configuration files to run portage/gatecheck on gatecheck itself. When running portage run -v all, the verbose logging level was not being passed to gatecheck making debugging harder. This was fixed because the git context wasn't showing up in the manifest and I needed better debugging. It turned out that the gatecheck bundle create wasn't being called if the tar.gz file was already there. Files were being appended & replaced in the existing. New logic was added to delete the existing bundle for a new portage run all.